### PR TITLE
Added support for IDs on target URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-    if (changeInfo.status == 'complete' && tab.url === "https://web.whatsapp.com/") {
+    if (changeInfo.status == 'complete' && tab.url.includes('https://web.whatsapp.com/')) {
         chrome.tabs.executeScript(null, {
             file: 'make-dark-mode.js'
         });


### PR DESCRIPTION
Now target URL for enabling the dark mode doesn't need to be exactly `https://web.whatsapp.com/` but can also be, for example, `https://web.whatsapp.com/#id_tag`